### PR TITLE
Fix Jenkins Docker socket permissions in docker-compose

### DIFF
--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     environment:
       - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
     container_name: jenkins
+    user: root  # Run as root to access Docker socket
+    command: >
+      sh -c "
+      usermod -aG docker jenkins &&
+      chmod 666 /var/run/docker.sock &&
+      su jenkins -c '/usr/bin/tini -- /usr/local/bin/jenkins.sh'
+      "
 
 volumes:
   jenkins-data:


### PR DESCRIPTION
- Add root user configuration for Docker socket access
- Add usermod command to add jenkins user to docker group
- Add chmod command to set proper socket permissions
- Use command override to run permission setup on container start
- This resolves Docker permission issues in Jenkins pipeline